### PR TITLE
[FELIX-5626] Exclude EasyMock from the runtime classpath

### DIFF
--- a/bundlerepository/pom.xml
+++ b/bundlerepository/pom.xml
@@ -98,6 +98,7 @@
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
         <version>3.4</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
... and move it to the test classpath instead.